### PR TITLE
Fix security config settings 

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -16,7 +16,7 @@ Il NE doit PAS être modifié à la main.
 
 ## Vue d’ensemble
 
-Ceci est une fausse description des fonctionalités de l'app
+Logiciel pour gérer des revues scientifiques
 
 
 **Version incluse :** 3.4.0-7~ynh1

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -96,7 +96,7 @@ restful_urls = Off
 ; An empty string indicates that all hosts should be trusted (not recommended!)
 ; Example:
 ; allowed_hosts = '["myjournal.tld", "anotherjournal.tld", "mylibrary.tld"]'
-allowed_hosts = '__DOMAIN__'
+allowed_hosts = '["__DOMAIN__"]'
 
 ; Allow the X_FORWARDED_FOR header to override the REMOTE_ADDR as the source IP
 ; Set this to "On" if you are behind a reverse proxy and you control the X_FORWARDED_FOR

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -146,9 +146,9 @@ sandbox = Off
 
 driver = mysqli
 host = localhost
-username = __DB_USER__
-password = "__DB_PWD__"
-name = __DB_NAME__
+username = 
+password = 
+name = 
 
 ; Set the non-standard port and/or socket, if used
 ; port = 3306

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -336,7 +336,7 @@ sendmail_path = "/usr/sbin/sendmail -bs"
 ; allow_envelope_sender = Off
 
 ; Default envelope sender to use if none is specified elsewhere
-; default_envelope_sender = my_address@my_host.com
+ default_envelope_sender = __APP__@__DOMAIN__
 
 ; Force the default envelope sender (if present)
 ; This is useful if setting up a site-wide no-reply address

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -30,7 +30,7 @@ app_key = __APP_KEY__
 
 ; Set this to On once the system has been installed
 ; (This is generally done automatically by the installer)
-installed = On
+installed = Off
 
 ; The canonical URL to the OJS installation (excluding the trailing slash)
 base_url = "__DOMAIN____PATH__"

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,1 +1,1 @@
-Ceci est une fausse description des fonctionalités de l'app
+Logiciel pour gérer des revues scientifiques

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -5,3 +5,8 @@ Name = __DB_NAME__
 
 **Data directory**
 __DATA_DIR__
+
+**SMTP settings**
+SMTP_LOGIN=__APP__
+SMTP_PASSWORD=__MAIL_PWD__
+SMTP_FROM_ADDRESS= <__APP__@__DOMAIN__>

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -10,8 +10,7 @@ ynh_script_progression "Updating NGINX web server configuration..."
 
 ynh_config_change_url_nginx
 
-ynh_replace_string --match_string="__OLD_DOMAIN____OLD_PATH__" --replace_string="__NEW_DOMAIN____NEW_PATH__" --target_file="$install_dir/config.inc.php"
-
+ynh_config_add --template="config.inc.php" --destination="$install_dir/config.inc.php"
 chmod 600 "$install_dir/config.inc.php"
 chown "$app:$app" "$install_dir/config.inc.php"
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -10,6 +10,11 @@ ynh_script_progression "Updating NGINX web server configuration..."
 
 ynh_config_change_url_nginx
 
+ynh_replace_string --match_string="__OLD_DOMAIN____OLD_PATH__" --replace_string="__NEW_DOMAIN____NEW_PATH__" --target_file="$install_dir/config.inc.php"
+
+chmod 600 "$install_dir/config.inc.php"
+chown "$app:$app" "$install_dir/config.inc.php"
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -37,10 +37,10 @@ ynh_config_add_nginx
 #=================================================
 ynh_script_progression "Adding app's configuration file..."
 
-#ynh_config_add --template="config.inc.php" --destination="$install_dir/config.inc.php"
+ynh_config_add --template="config.inc.php" --destination="$install_dir/config.inc.php"
 
-#chmod 600 "$install_dir/config.inc.php"
-#chown "$app:$app" "$install_dir/config.inc.php"
+chmod 600 "$install_dir/config.inc.php"
+chown "$app:$app" "$install_dir/config.inc.php"
 
 ynh_config_add --template=".cron" --destination="/etc/cron.d/$app"
 


### PR DESCRIPTION
Some security config settings are empty

## Problem

- *app key, api key and salt are empty*

## Solution

- *add config template to install script*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
