### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -15,7 +15,7 @@ ynh_app_setting_set --key=locale --value=$locale
 
 admin_mail=$(ynh_user_get_info --username=$admin --key=mail)
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 ynh_app_setting_set --key=timezone --value=$timezone
 
 timezone_formatted=$(format_timezone "$timezone")


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.